### PR TITLE
fix: remove duplicate bundle script injection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,5 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="/bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR fixes duplicate app bundle loading in production output by removing the manually hardcoded bundle script from the HTML template and relying on HtmlWebpackPlugin injection only.

Problem
The generated [index.html:1]was including bundle.js twice:

Auto-injected by HtmlWebpackPlugin
Manually hardcoded in [index.html:10]
This could cause duplicate app bootstrap behavior and avoidable runtime overhead.

Changes Made
Removed the manual script tag from [index.html:10]
Validation
Ran a clean production build
Checked generated output in [index.html:1]
Verified bundle reference count is now 1 (previously 2)
Impact
Prevents potential double initialization and duplicate side effects
Reduces unnecessary parse and execution overhead
Removes brittle hardcoded absolute bundle path from template
Related Issue
Closes #3