### PR TITLE
fix: align RVA23 profile IDs and add profile consistency validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://rpsene.github.io/riscv-extensions-landscape/",
 "scripts": {
   "build": "webpack",
+  "validate:profiles": "node scripts/validate_profiles.mjs",
   "predeploy": "npm run build",
   "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
   "test": "echo \"Error: no test specified\" && exit 1"

--- a/scripts/validate_profiles.mjs
+++ b/scripts/validate_profiles.mjs
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function findMatchingBrace(text, openIndex) {
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let inTemplate = false;
+  let escape = false;
+
+  for (let i = openIndex; i < text.length; i += 1) {
+    const ch = text[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      if (inSingle || inDouble || inTemplate) escape = true;
+      continue;
+    }
+
+    if (inSingle) {
+      if (ch === "'") inSingle = false;
+      continue;
+    }
+
+    if (inDouble) {
+      if (ch === '"') inDouble = false;
+      continue;
+    }
+
+    if (inTemplate) {
+      if (ch === '`') inTemplate = false;
+      continue;
+    }
+
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+
+    if (ch === '`') {
+      inTemplate = true;
+      continue;
+    }
+
+    if (ch === '{') depth += 1;
+    if (ch === '}') depth -= 1;
+
+    if (depth === 0) return i;
+  }
+
+  return -1;
+}
+
+function extractProfiles(jsxText) {
+  const marker = 'const profiles =';
+  const markerIndex = jsxText.indexOf(marker);
+  if (markerIndex === -1) {
+    die('Could not find `const profiles =` in src/risc_v_visualizer.jsx');
+  }
+
+  const braceStart = jsxText.indexOf('{', markerIndex);
+  if (braceStart === -1) {
+    die('Could not find opening `{` for profiles object in src/risc_v_visualizer.jsx');
+  }
+
+  const braceEnd = findMatchingBrace(jsxText, braceStart);
+  if (braceEnd === -1) {
+    die('Could not find closing `}` for profiles object in src/risc_v_visualizer.jsx');
+  }
+
+  const objectLiteral = jsxText.slice(braceStart, braceEnd + 1);
+  return vm.runInNewContext(`(${objectLiteral})`, {}, { timeout: 1000 });
+}
+
+const workspaceRoot = process.cwd();
+const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
+const visualizerPath = path.join(workspaceRoot, 'src', 'risc_v_visualizer.jsx');
+
+const extensionsCatalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+const visualizerSource = fs.readFileSync(visualizerPath, 'utf8');
+const profiles = extractProfiles(visualizerSource);
+
+const extensionIds = new Set(
+  Object.values(extensionsCatalog)
+    .flat()
+    .filter(Boolean)
+    .map((ext) => ext.id)
+);
+
+const unknownByProfile = [];
+
+for (const [profile, ids] of Object.entries(profiles)) {
+  if (!Array.isArray(ids)) continue;
+  const unknown = Array.from(new Set(ids.filter((id) => !extensionIds.has(id)))).sort();
+  if (unknown.length) {
+    unknownByProfile.push({ profile, unknown });
+  }
+}
+
+if (unknownByProfile.length) {
+  console.error('Profile validation failed: unknown extension IDs detected.');
+  for (const item of unknownByProfile) {
+    console.error(`- ${item.profile}: ${item.unknown.join(', ')}`);
+  }
+  process.exit(1);
+}
+
+console.log('Profile validation passed: all profile extension IDs exist in src/riscv_extensions.json.');

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1042,7 +1042,6 @@ const RISCVExplorer = () => {
       'Ssu64xl',
 
       // Hypervisor bundle
-      'Sha',
       'H',
     ],
 


### PR DESCRIPTION
This PR fixes a profile data consistency bug in RVA23 and adds a validation guard to prevent similar mismatches in future updates.

What was the issue
RVA23 profile list had an unknown extension ID: Sha.
That ID does not exist in the extension catalog, so profile highlighting and profile coverage logic had a silent mismatch.

Why this was important
Profile data shown to users was not fully accurate for RVA23.
Declared profile requirements and renderable/highlightable extensions were not aligned.
This kind of mismatch could happen again because there was no automated validation.
Root cause
A profile ID drift happened between profile definitions and the extension catalog:

RVA23 included Sha in profile definitions
Catalog had no matching extension entry for Sha
Changes made
Removed the invalid Sha reference from RVA23 profile definitions.
Added a profile consistency validator script that checks profile IDs against catalog IDs.
Added an npm script to run this validation in a repeatable way.
Validation and output
Validation was run after the fix and passed successfully.

Observed profile consistency after fix:

RVA20: unknown=0
RVA22: unknown=0
RVA23: unknown=0
RVB23: unknown=0
Validator output:

Profile validation passed: all profile extension IDs exist in src/riscv_extensions.json.
Build verification:

Production build completed successfully (exit code 0).
Existing webpack bundle size warnings remain unchanged and are unrelated to this fix.
Impact
Restores correct RVA23 profile consistency.
Prevents silent profile/catalog drift going forward.
Improves trustworthiness of profile-based highlighting and compliance interpretation.
Related issue
Closes #<#5>