### PR TITLE
fix: added missing SLO things in UI

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1510,6 +1510,9 @@ const RISCVExplorer = () => {
 
       // Zbb: Logical operations
       'ANDN', 'ORN', 'XNOR',
+      // Zbb: Deprecated logical operations
+      // adding these manually bcoz they are missing lol
+      'SLO', 'SLOI', 'SRO', 'SROI',
       // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
       'CLZW', 'CTZW', 'CPOPW',
@@ -1540,7 +1543,12 @@ const RISCVExplorer = () => {
     Zbb: [
       // Logical operations
       'ANDN', 'ORN', 'XNOR',
-      // Count leading/trailing zeros and population count
+      // logical operations that are old I guess
+      'SLO', 
+      'SLOI', // not sure why this one has I but whatever
+      'SRO', 
+      'SROI',
+      // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
       // RV64 word variants
       'CLZW', 'CTZW', 'CPOPW',

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1511,7 +1511,6 @@ const RISCVExplorer = () => {
       // Zbb: Logical operations
       'ANDN', 'ORN', 'XNOR',
       // Zbb: Deprecated logical operations
-      // adding these manually bcoz they are missing lol
       'SLO', 'SLOI', 'SRO', 'SROI',
       // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
@@ -1543,11 +1542,8 @@ const RISCVExplorer = () => {
     Zbb: [
       // Logical operations
       'ANDN', 'ORN', 'XNOR',
-      // logical operations that are old I guess
-      'SLO', 
-      'SLOI', // not sure why this one has I but whatever
-      'SRO', 
-      'SROI',
+      // Deprecated logical operations
+      'SLO', 'SLOI', 'SRO', 'SROI',
       // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
       // RV64 word variants


### PR DESCRIPTION
This pull request addresses an issue where four deprecated instructions (SLO, SLOI, SRO, SROI) were present in the source catalog ([riscv_extensions.json](https://potential-sniffle-xj64w9557q53pqw5.github.dev/)) but were omitted from the UI visualizer groupings. As a result, they were not rendered in the Instruction Set Snapshot or available for per-mnemonic navigation in the application.

Changes Proposed:

Added 'SLO', 'SLOI', 'SRO', 'SROI' to the [B](https://potential-sniffle-xj64w9557q53pqw5.github.dev/) (Bit-Manipulation) and [Zbb](https://potential-sniffle-xj64w9557q53pqw5.github.dev/) instruction arrays within [risc_v_visualizer.jsx](https://potential-sniffle-xj64w9557q53pqw5.github.dev/).
Removed the undocumented/orphaned state for these instructions so they correctly display their encoding metadata directly from the JSON definitions.
Motivation and Context:
Maintaining parity between the data source ([riscv_extensions.json](https://potential-sniffle-xj64w9557q53pqw5.github.dev/)) and the visualization arrays ([risc_v_visualizer.jsx](https://potential-sniffle-xj64w9557q53pqw5.github.dev/)) is essential for an accurate representation of the instruction sets, including deprecated instructions which still carry valid encodings. This change restores visibility for these missing items.

Testing Performed:

Local Build: Verified npm run build completes successfully without any compilation errors or warnings regarding these additions.
Logic Check: Verified the JSON encoding masks and opcodes for these instructions map correctly in the UI.
Type of Change:
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)